### PR TITLE
Delete syslbek

### DIFF
--- a/syslbek
+++ b/syslbek
@@ -1,2 +1,0 @@
-key "ecc8dda94b35abbb9a7a5ec22b8deef7b6cfec496ad9fa47819b2057669608c2";
-remote "syslbek.freifunk-suedholstein.de" port 10000;


### PR DESCRIPTION
Falsche Schreibweise für Sylsbek